### PR TITLE
Cloud Foundry forward-compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ before_script:
 script: nosetests -s
 
 env:
-- GITHUB_USER=test_user GITHUB_AUTH=sample_key VCAP_APP_PORT=8080 ENV=local HTUSER=18f HTAUTH=4usa FLASK_CONFIG=testing PROD=localhost STAGING=localhost
+- GITHUB_USER=test_user GITHUB_AUTH=sample_key PORT=8080 ENV=local HTUSER=18f HTAUTH=4usa FLASK_CONFIG=testing PROD=localhost STAGING=localhost


### PR DESCRIPTION
Per [Cloud Foundry documentation](https://docs.cloudfoundry.org/running/apps-enable-diego.html#app-code) use of `$VCAP_APP_HOST` and `$VCAP_APP_PASSWORD` are incompatible with newer (Diego-based) Cloud Foundry deployments. This change makes this repository forward compatible with the new cloud.gov environment deployment in AWS GovCloud.
