### PR TITLE
Cloud Foundry forward-compatibility

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -39,7 +39,7 @@ def updatedata(days=0):
 
 @manager.command
 def deploy():
-    port = int(environ["VCAP_APP_PORT"])
+    port = int(environ["PORT"])
     serve(app, port=port)
 
 


### PR DESCRIPTION
Per [Cloud Foundry documentation](https://docs.cloudfoundry.org/running/apps-enable-diego.html#app-code) use of `$VCAP_APP_HOST` and `$VCAP_APP_PASSWORD` are incompatible with newer (Diego-based) Cloud Foundry deployments. This change makes this repository forward compatible with the new cloud.gov environment deployment in AWS GovCloud.
